### PR TITLE
feat[0007]: HashMap

### DIFF
--- a/__383__/README.md
+++ b/__383__/README.md
@@ -1,0 +1,22 @@
+# 383. Ranson Note
+## Problem Statement
+Given two strings `ransomNote` and `magazine`, return `true` if `ransomNote` can be constructed by using the letters from `magazine` and `false` otherwise.
+
+Each letter in `magazine` can only be used once in `ransomNote`.
+
+Example 1:
+    Input: ransomNote = "a", magazine = "b"
+    Output: false
+
+Example 2:
+    Input: ransomNote = "aa", magazine = "ab"
+    Output: false
+
+Example 3:
+    Input: ransomNote = "aa", magazine = "aab"
+    Output: true
+
+Constraints:
+`1 <= ransomNote.length, magazine.length <= 10^5`
+`ransomNote` and `magazine` consist of lowercase English letters.
+

--- a/__383__/hashMap.js
+++ b/__383__/hashMap.js
@@ -1,0 +1,32 @@
+/**
+ * @param {string} ransomNote
+ * @param {string} magazine
+ * @return {boolean}
+ */
+const canConstruct = (ransomNote, magazine) => {
+  // Create a has map (or object) to count characters in magazine
+  const letterCounts = {};
+
+  // For each character in magazine:
+  for (let char of magazine) {
+    // Increment its count in the hash map
+    letterCounts[char] = (letterCounts[char] || 0) + 1;
+  }
+
+  // For each character in ransomNote:
+  for (let char of ransomNote) {
+    // If the character is not in the hash map its count is 0:
+    if (!letterCounts[char]) {
+      // Return false (not enough letters)
+      return false;
+    }
+    // Otherwise:
+    // Decrement the count of that character in the hash map
+    letterCounts[char]--;
+  }
+
+  // If all characters in ransomNote are matched:
+  return true;
+};
+
+module.exports = { canConstruct };

--- a/__383__/hashMap.test.js
+++ b/__383__/hashMap.test.js
@@ -1,0 +1,19 @@
+const { canConstruct } = require("./hashMap.js");
+
+describe("canConstruct", () => {
+  test('should return false when ransomNote = "a", magazine = "b"', () => {
+    expect(canConstruct("a", "b")).toBe(false);
+  });
+  test('should return false when ransomNote == "aa", magazine = "ab"', () => {
+    expect(canConstruct("aa", "ab")).toBe(false);
+  });
+  test('should return true when ransomNote = "aa", magazine = "aab"', () => {
+    expect(canConstruct("aa", "aab")).toBe(true);
+  });
+  test("should return true for empty ransomNote", () => {
+    expect(canConstruct("", "abc")).toBe(true);
+  });
+  test("should return false for empty magazine and non-empty ransomNote", () => {
+    expect(canConstruct("a", "")).toBe(false);
+  });
+});


### PR DESCRIPTION
**Description**
This PR adds a solution for the HashMap problem (LeetCode #383) along with comprehensive Jest unit tests.

**Changes include:**
`canConstruct` function that checks if the ransom note can be formed from thr magazine letters.
Edge case handling for empty strings and mismatched inputs.